### PR TITLE
Add option WebSettings#setSavePassword(false) for forward compatibility.

### DIFF
--- a/library/src/main/java/com/kazy/lx/LxWebView.java
+++ b/library/src/main/java/com/kazy/lx/LxWebView.java
@@ -104,6 +104,10 @@ public class LxWebView extends WebView {
         setting.setSupportMultipleWindows(supportMultipleWindows);
         setting.setSupportZoom(supportZoom);
         setting.setUseWideViewPort(useWideViewPort);
+
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+            setting.setSavePassword(false);
+        }
     }
 
     public void addLoadingInterceptor(LoadingInterceptor loadingInterceptor) {

--- a/library/src/main/java/com/kazy/lx/LxWebView.java
+++ b/library/src/main/java/com/kazy/lx/LxWebView.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.res.TypedArray;
 import android.graphics.Bitmap;
 import android.net.Uri;
+import android.os.Build;
 import android.util.AttributeSet;
 import android.webkit.WebChromeClient;
 import android.webkit.WebSettings;


### PR DESCRIPTION
After KitKat, WebView behave as WebSettings#setSavePassword(false).
But pre-KitKat, WebView intend to store password without this option.

This patch is forcibly set this option to WebView inside of LxWebView.
