### PR TITLE
Add LxWebView#loadUrl() with request header option.

### DIFF
--- a/library/src/main/java/com/kazy/lx/LxWebContainerView.java
+++ b/library/src/main/java/com/kazy/lx/LxWebContainerView.java
@@ -13,6 +13,8 @@ import android.widget.Button;
 import android.widget.ProgressBar;
 import android.widget.RelativeLayout;
 
+import java.util.Map;
+
 public class LxWebContainerView extends RelativeLayout {
 
     private LxWebView lxWebView;
@@ -115,6 +117,10 @@ public class LxWebContainerView extends RelativeLayout {
 
     public void loadUrl(String url) {
         lxWebView.loadUrl(url);
+    }
+
+    public void loadUrl(String url, Map<String, String> additionalHttpHeaders) {
+        lxWebView.loadUrl(url, additionalHttpHeaders);
     }
 
     public boolean canGoBack() {

--- a/library/src/main/java/com/kazy/lx/LxWebView.java
+++ b/library/src/main/java/com/kazy/lx/LxWebView.java
@@ -13,6 +13,7 @@ import android.webkit.WebViewClient;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class LxWebView extends WebView {
 
@@ -175,6 +176,14 @@ public class LxWebView extends WebView {
             return;
         }
         super.loadUrl(url);
+    }
+
+    @Override
+    public void loadUrl(String url, Map<String, String> additionalHttpHeaders) {
+        if (intercept(Uri.parse(url))) {
+            return;
+        }
+        super.loadUrl(url, additionalHttpHeaders);
     }
 
     private boolean intercept(Uri uri) {


### PR DESCRIPTION
LxWebView doesn't have two-parameter loadUrl() method.
This patch is add LxWebView#loadUrl(url, header).

But, I think this API design is slightly splay...
But I don't know what I do. Tentatively PR for now.
